### PR TITLE
Fix cors issue

### DIFF
--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -13,9 +13,11 @@ const app = new Hono().basePath("/api").use(
       "http://localhost:3000",
       "https://project-management-beryl-five.vercel.app",
     ],
+    allowMethods: ["GET", "POST", "PATCH", "DELETE"],
+    allowHeaders: ["Content-Type", "Authorization"],
+    credentials: true,
   })
 );
-app.use();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const routes = app
   .route("/auth", auth)

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { handle } from "hono/vercel";
 import auth from "@/features/auth/server/route";
 import workspace from "@/features/workspace/server/route";
@@ -6,7 +7,15 @@ import member from "@/features/members/server/route";
 import project from "@/features/projects/server/route";
 import task from "@/features/tasks/server/route";
 
-const app = new Hono().basePath("/api");
+const app = new Hono().basePath("/api").use(
+  cors({
+    origin: [
+      "http://localhost:3000",
+      "https://project-management-beryl-five.vercel.app",
+    ],
+  })
+);
+app.use();
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const routes = app
   .route("/auth", auth)


### PR DESCRIPTION
This pull request adds Cross-Origin Resource Sharing (CORS) support to the API routes in the `src/app/api/[[...route]]/route.ts` file. The change ensures that the API can handle requests from specific origins with appropriate headers and methods.

### CORS configuration added:

* `src/app/api/[[...route]]/route.ts`: Integrated the `hono/cors` middleware to enable CORS, allowing requests from `http://localhost:3000` and `https://project-management-beryl-five.vercel.app` with specified methods (`GET`, `POST`, `PATCH`, `DELETE`) and headers (`Content-Type`, `Authorization`). Credentials support is also enabled. ([src/app/api/[[...route]]/route.tsR2-R20](diffhunk://#diff-087a4afc4f41c98907de10383d7019c624a5216fdf90a1496a3cef40fb87227dR2-R20))