### PR TITLE
feat(zustand-persist): Implement zustand-persist

### DIFF
--- a/src/states/user-profile.ts
+++ b/src/states/user-profile.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 
 type UserProfileState = {
   isOpen: boolean;
@@ -7,9 +8,18 @@ type UserProfileState = {
   toggleUserProfile: () => void;
 };
 
-export const userProfileViewStore = create<UserProfileState>((set) => ({
-  isOpen: false,
-  openUserProfile: () => set({ isOpen: true }),
-  closeUserProfile: () => set({ isOpen: false }),
-  toggleUserProfile: () => set((state) => ({ isOpen: !state.isOpen })),
-}));
+export const userProfileViewStore = create<UserProfileState>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      openUserProfile: () => set({ isOpen: true }),
+      closeUserProfile: () => set({ isOpen: false }),
+      toggleUserProfile: () => set((state) => ({ isOpen: !state.isOpen })),
+    }),
+    {
+      name: "user-profile-view",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ isOpen: state.isOpen }),
+    }
+  )
+);


### PR DESCRIPTION
This pull request introduces state persistence for the `userProfileViewStore` in the `src/states/user-profile.ts` file using the `zustand` middleware. The most important changes include adding persistence functionality and configuring it to store the `isOpen` state in `localStorage`.

### State persistence implementation:
* Added `zustand/middleware` imports to enable state persistence (`persist` and `createJSONStorage`) in `src/states/user-profile.ts`.
* Updated the `userProfileViewStore` to use the `persist` middleware, configured with:
  - A `name` of `"user-profile-view"` for the storage key.
  - `localStorage` as the storage mechanism.
  - A `partialize` function to persist only the `isOpen` property of the state.- configure zustand persist
- add zustand persist to the profile-view section